### PR TITLE
新增確認刪除視窗，同時使用 Consumer 來建立餐廳列表

### DIFF
--- a/lib/widgets/card.dart
+++ b/lib/widgets/card.dart
@@ -3,6 +3,8 @@ import 'package:intl/intl.dart';
 
 import '../firebase/model.dart';
 import '../pages/restaurants_page.dart';
+import '../widgets/dialog.dart';
+import '../logging/logging.dart';
 
 class ListDismissibleCard extends StatelessWidget{
 
@@ -60,6 +62,16 @@ class ListDismissibleCard extends StatelessWidget{
           padding: const EdgeInsets.symmetric(horizontal: 20),
           child: Icon(Icons.delete, color: theme.colorScheme.onError),
         ),
+        confirmDismiss: (direction) async {
+          final result = await showDialog<bool>(
+            context: context,
+            builder: (context) {
+              return DoubleCheckDismissDialog();
+            },
+          );
+          logger.d('Confirm result for dismiss list: $result');
+          return result ?? false;
+        },
         onDismissed: (direction) => onDismissed!(),
         child: card,
       );
@@ -147,6 +159,16 @@ class RestaurantDismissibleCard extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 20),
           child: Icon(Icons.delete, color: theme.colorScheme.onError),
         ),
+        confirmDismiss: (direction) async {
+          final result = await showDialog<bool>(
+            context: context,
+            builder: (context) {
+              return DoubleCheckDismissDialog();
+            },
+          );
+          logger.d('Confirm result for dismiss restaurant: $result');
+          return result ?? false;
+        },
         onDismissed: (direction) => onDismissed!(),
         child: card,
       );

--- a/lib/widgets/card.dart
+++ b/lib/widgets/card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
+import '../states/app_state.dart';
 import '../firebase/model.dart';
 import '../pages/restaurants_page.dart';
 import '../widgets/dialog.dart';
@@ -41,6 +43,8 @@ class ListDismissibleCard extends StatelessWidget{
         ),
         subtitleTextStyle: theme.textTheme.titleSmall,
         onTap: () {
+          Provider.of<AppState>(context, listen: false)
+            .setSelectedListID(list.listID);
           Navigator.of(context).push(
             MaterialPageRoute(
               builder: (context) => RestaurantsListScreen(list: list, editable: fromPersonal),

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -663,3 +663,41 @@ class _PublicizePersonalListDialogState extends State<PublicizePersonalListDialo
     );
   }
 }
+
+class DoubleCheckDismissDialog extends StatelessWidget {
+  const DoubleCheckDismissDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      backgroundColor: theme.colorScheme.surface,
+      title: Center(
+        child: Text('確認刪除', style: theme.textTheme.titleLarge)
+      ),
+      content: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Text(
+          '確定要刪除這個清單/餐廳嗎？', 
+          style: theme.textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+      ),
+      actions: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            WhiteElevatedButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              label: const Text('取消'),
+            ),
+            PrimaryElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              label: const Text('確定'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
當左滑清單或餐廳卡片時，會彈跳出確認視窗，讓使用者再次確認是否要刪除，以免使用者不小心左滑造成誤刪。

`RestaurantDismissibleCard` 是透過 `StreamBuilder` 所建立的，這個方法會一直刷新 UI 元件，即便 Firestore 沒有任何資料變動。因為一直刷新，導致 `RestaurantDismissibleCard` 本身的 `context` 一直重建，無法正確接收到 `DoubleCheckDismissDialog` 的結果，所以就不會執行 `onDismissed` 函式。

解決方法是不使用 `StreamBuilder` 來建立，改採用像主頁建立清單列表的方式，透過 `appState` 取得訂閱內容，然後使用 `Consumer` 來呈現。

改用 `Consumer` 來呈現後，應該就不會在看到畫面一直頻繁刷新，尤其是當在某個清單內，按下新增清單後，清單頁面不會再出現閃爍。

|  清單   | 餐廳  |
|  ----  | ----  |
| ![image](https://github.com/user-attachments/assets/7c31c843-6937-4367-bc61-7ccb1d0d7dd5)  | ![image](https://github.com/user-attachments/assets/7df057fe-a966-474d-9c51-0950ea6554e5) |