### PR TITLE
restaurant card shows detail

### DIFF
--- a/lib/widgets/card.dart
+++ b/lib/widgets/card.dart
@@ -111,7 +111,11 @@ class RestaurantDismissibleCard extends StatelessWidget {
           crossAxisAlignment : CrossAxisAlignment.start,
           children: [
             Text('地址: ${restaurant.address}'),
-            Text('描述: ${restaurant.description}'),
+            Text(
+              '描述: ${restaurant.description}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
             const SizedBox(height: 6),
             Wrap(
               spacing: 2,
@@ -151,7 +155,10 @@ class RestaurantDismissibleCard extends StatelessWidget {
         ),
         subtitleTextStyle: theme.textTheme.titleSmall,
         onTap: () {
-          // TODO 點擊餐廳卡片，顯示更多內容、以 Map 開啟、返回餐廳列表等功能
+          showDialog(
+            context: context, 
+            builder: (context) => ShowRestaurantDialog(restaurant: restaurant)
+          );
         },
         onLongPress: () {
           if (fromPersonal) {

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -804,6 +804,101 @@ class DoubleCheckDismissDialog extends StatelessWidget {
   }
 }
 
+class ShowRestaurantDialog extends StatelessWidget {
+  final Restaurant restaurant;
+  const ShowRestaurantDialog({
+    required this.restaurant,
+    super.key
+  });
+
+  void _launchGoogleMap(String name, String address) {
+    final url = 'https://www.google.com/maps/search/?api=1&query=${Uri.encodeComponent('$name $address')}';
+    launchUrl(Uri.parse(url));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [Text(restaurant.name)],),
+      content: Padding(
+        padding: EdgeInsets.all(8),
+        child: Wrap(
+          spacing: 2,
+          runSpacing: 24,
+          alignment: WrapAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.location_on_sharp),
+                const SizedBox(width: 4,),
+                Flexible(
+                  child: GestureDetector(
+                    onTap: () => _launchGoogleMap(restaurant.name, restaurant.address),
+                    child: Text(
+                      restaurant.address,
+                      softWrap: true,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Icon(Icons.description),
+                const SizedBox(width: 4,),
+                Flexible(
+                  child: Container(
+                    constraints: BoxConstraints(
+                      maxHeight: 180,
+                    ),
+                    child: SingleChildScrollView(
+                      child: Text(
+                        restaurant.description,
+                        softWrap: true,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Icon(Icons.restaurant_menu),
+                const SizedBox(width: 4,),
+                Text(restaurant.type)
+              ],
+            ),
+            Row(
+              children: [
+                Icon(Icons.attach_money),
+                const SizedBox(width: 4,),
+                Text(restaurant.price)
+              ],
+            ),
+            Row(
+              children: [
+                Icon(Icons.ac_unit),
+                const SizedBox(width: 4,),
+                Text(restaurant.hasAC ? '有冷氣' : '沒有冷氣')
+              ],
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text('關閉'),
+        ),
+      ],
+      actionsAlignment: MainAxisAlignment.center,
+    );
+  }
+}
+
+
 
 class EditRestaurantDialog extends StatefulWidget {
   const EditRestaurantDialog({


### PR DESCRIPTION
按下restaurant card可以秀出詳細資訊的dialog

原本的RestaurantDismissibleCard裡面的'描述'改成只有一行，overflow的文字直接ellipsis，避免描述過長佔據版面
詳細的描述放在ShowRestaurantDialog裡面，使用BoxConstraint與SingleChildScrollView控制高度並讓其可以滾動查看完整描述

地址位置可以點擊，會跳轉到google map，並以 "restaurant.name restaurant.address" 方式進行搜尋

<img src='https://github.com/user-attachments/assets/ec53e462-b47e-4fab-b060-346b12836834' width=300>
<img src='https://github.com/user-attachments/assets/7c66e5a8-e3d8-43be-a1de-732f89d4985b' width=300>
<img src='https://github.com/user-attachments/assets/2bfb7e9d-4a82-4e69-b53a-0b84510db3b3' width=300>