### PR TITLE
fix: 修復餐廳名稱太長導致 overflow

### DIFF
--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -823,9 +823,8 @@ class ShowRestaurantDialog extends StatelessWidget {
     final theme = Theme.of(context);
     return AlertDialog(
       backgroundColor: theme.colorScheme.surface,
-      title: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [Text(restaurant.name)],
+      title: Center(
+        child: Text(restaurant.name, style: theme.textTheme.titleLarge)
       ),
       content: Padding(
         padding: EdgeInsets.all(8),


### PR DESCRIPTION
修復 issue #20，點擊餐廳後，餐廳卡片的 title 不會 overflow。

<img src="https://github.com/user-attachments/assets/fffaa244-6170-4e1c-8d40-f69738b495e2" width="300">