### PR TITLE
fix: 修復轉盤顯示的不一致問題

### DIFF
--- a/lib/pages/restaurants_page.dart
+++ b/lib/pages/restaurants_page.dart
@@ -47,6 +47,7 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
     final StreamController<int> controller = StreamController<int>();
     final random = Random();
     final selectedIndex = random.nextInt(restaurants.length);
+    controller.add(selectedIndex);
     final theme = Theme.of(context);
 
     showDialog(


### PR DESCRIPTION
修復 issue #23，使轉盤結果與呈現餐廳結果維持一致。

使用 `controller.add()` 決定最終選擇餐廳的結果。