### PR TITLE
實作共享清單

### DIFF
--- a/lib/firebase/constants.dart
+++ b/lib/firebase/constants.dart
@@ -23,6 +23,7 @@ class PersonalListFields {
   static const String isPublic = 'isPublic';
   static const String creatTime = 'creatTime';
   static const String updateTime = 'updateTime';
+  static const String shareWith = 'shareWith';
 }
 
 class RestaurantFields {

--- a/lib/firebase/firebase_service.dart
+++ b/lib/firebase/firebase_service.dart
@@ -636,5 +636,174 @@ class FirebaseService {
     }
     return response;
   }
+
+  /// 透過 listID，獲取該清單的共享使用者資訊
+  static Future<GetSharedUsersResponse> getSharedUser({
+    required String listID,
+  }) async {
+    final response = GetSharedUsersResponse(success: false, message: '');
+    response.usersList = [];
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      response.message = '尚未登入，無法新增共享使用者';
+      return response;
+    }
+
+    try {
+      DocumentSnapshot listDoc = await FirebaseFirestore.instance
+        .collection(CollectionNames.personalLists)
+        .doc(listID)
+        .get();
+
+      if (!listDoc.exists) {
+        response.message = '找不到指定的清單';
+        return response;
+      }
+
+      final shareWithData = listDoc.data() as Map<String, dynamic>?;
+      List<String> shareWithList = List<String>.from(shareWithData?[PersonalListFields.shareWith] ?? []);
+
+      List<Map<String, dynamic>> usersList = [];
+      for (String userId in shareWithList) {
+        DocumentSnapshot userDoc = await FirebaseFirestore.instance
+          .collection(CollectionNames.users)
+          .doc(userId)
+          .get();
+
+        if (userDoc.exists) {
+          usersList.add({
+            PersonalListFields.userID: userId,
+            UserFileds.email: userDoc[UserFileds.email] ?? '未知',
+            UserFileds.userName: userDoc[UserFileds.userName] ?? '未知',
+          });
+        }
+      }
+      response.success = true;
+      response.message = '成功獲取共享使用者資訊';
+      response.usersList = usersList;
+
+    } catch(e) {
+      logger.w('Get shared user failed.\nUnknown error $e');
+      response.message = '獲取共享使用者失敗：$e';
+    }
+    return response;
+  }
+
+  /// 透過 email，新增個人清單裡的共享使用者
+  static Future<AddSharedUserByEmailResponse> addSharedUserByEmail({
+    required String listID,
+    required String email,
+  }) async {
+    final response = AddSharedUserByEmailResponse(success: false, message: '');
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      response.message = '尚未登入，無法新增共享使用者';
+      return response;
+    }
+
+    try {
+      QuerySnapshot queryUser = await FirebaseFirestore.instance
+        .collection(CollectionNames.users)
+        .where(UserFileds.email, isEqualTo: email)
+        .get();
+
+      if (queryUser.docs.isEmpty) {
+        response.message = '找不到使用此電子郵件的使用者';
+        return response;
+      }
+
+      if (queryUser.docs.length > 1) {
+        response.message = '找到多個使用該電子郵件的使用者，請聯繫開發團隊';
+        return response;
+      }
+
+      DocumentSnapshot userDoc = queryUser.docs.first;
+      String userId = userDoc.id;
+
+      DocumentReference listRef = FirebaseFirestore.instance
+        .collection(CollectionNames.personalLists)
+        .doc(listID);
+
+      DocumentSnapshot listDoc = await listRef.get();
+
+      if (!listDoc.exists) {
+        response.message = '找不到指定的清單';
+        return response;
+      }
+
+      final shareWithData = listDoc.data() as Map<String, dynamic>?;
+      List<String> shareWithList = List<String>.from(shareWithData?[PersonalListFields.shareWith] ?? []);
+
+      if (shareWithList.contains(userId)) {
+        response.message = '此使用者已在共享列表中';
+        return response;
+      }
+
+      await listRef.update({
+        PersonalListFields.shareWith: FieldValue.arrayUnion([userId]),
+      });
+
+      logger.i('Add shared user: $email successfully from list: $listID');
+      response.success = true;
+      response.message = '成功新增共享使用者';
+
+    } catch (e) {
+      logger.w('Add shared user failed.\nUnknown error $e');
+      response.message = '新增共享使用者失敗：$e';
+    }
+    return response;
+  }
+
+  /// 從個人清單中移除共享使用者
+  static Future<RemoveSharedUserByEmailResponse> removeSharedUser({
+    required String listID,
+    required String userID,
+  }) async {
+    final response = RemoveSharedUserByEmailResponse(success: false, message: '');
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      response.message = '尚未登入，無法移除共享使用者';
+      return response;
+    }
+
+    try {
+      DocumentSnapshot listDoc = await FirebaseFirestore.instance
+        .collection(CollectionNames.personalLists)
+        .doc(listID)
+        .get();
+
+      if (!listDoc.exists) {
+        response.message = '找不到指定的清單';
+        return response;
+      }
+
+      final shareWithData = listDoc.data() as Map<String, dynamic>?;
+      List<String> shareWithList = List<String>.from(shareWithData?[PersonalListFields.shareWith] ?? []);
+
+      if (!shareWithList.contains(userID)) {
+        response.message = '此使用者不在共享列表中';
+        return response;
+      }
+
+      await FirebaseFirestore.instance
+          .collection(CollectionNames.personalLists)
+          .doc(listID)
+          .update({
+        PersonalListFields.shareWith: FieldValue.arrayRemove([userID]),
+      });
+
+      logger.i('Remove shared user: $userID successfully from list: $listID');
+      response.success = true;
+      response.message = '成功移除共享使用者';
+
+    } catch (e) {
+      logger.w('Remove shared user failed.\nUnknown error $e');
+      response.message = '移除共享使用者失敗：$e';
+    }
+    return response;
+  }
 }
 

--- a/lib/firebase/model.dart
+++ b/lib/firebase/model.dart
@@ -10,6 +10,7 @@ class PersonalList {
     required this.isPublic,
     this.creatTime,
     this.updateTime,
+    this.shareWith,
   });
 
   final String listID;
@@ -19,6 +20,7 @@ class PersonalList {
   final bool isPublic;
   final Timestamp? creatTime;
   final Timestamp? updateTime;
+  final List<String>? shareWith;
 
   DateTime? get creatTimeAsDate => creatTime?.toDate();
   DateTime? get updateTimeAsDate => updateTime?.toDate();
@@ -27,7 +29,7 @@ class PersonalList {
   String toString() {
     return 'PersonalList(listID: $listID, title: $title, userID: $userID, '
           'userName: $userName, isPublic: $isPublic, creatTime: ${creatTimeAsDate ?? '未知'}, '
-          'updateTime: ${updateTimeAsDate ?? '未知'})';
+          'updateTime: ${updateTimeAsDate ?? '未知'}, shareWith: $shareWith))';
   }
 }
 

--- a/lib/firebase/response.dart
+++ b/lib/firebase/response.dart
@@ -94,3 +94,25 @@ class UpdateRestaurantResponse {
   String message;
   DocumentReference? doc;
 }
+
+class GetSharedUsersResponse {
+  GetSharedUsersResponse({required this.success, required this.message});
+
+  bool success;
+  String message;
+  List<Map<String, dynamic>>? usersList;
+}
+
+class AddSharedUserByEmailResponse {
+  AddSharedUserByEmailResponse({required this.success, required this.message});
+
+  bool success;
+  String message;
+}
+
+class RemoveSharedUserByEmailResponse {
+  RemoveSharedUserByEmailResponse({required this.success, required this.message});
+
+  bool success;
+  String message;
+}

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -19,7 +19,7 @@ class _MainPageState extends State<MainPage>  with SingleTickerProviderStateMixi
   @override
   void initState(){
     super.initState();
-    _tabCtrl = TabController(length: 2, vsync: this);
+    _tabCtrl = TabController(length: 3, vsync: this);
     _tabCtrl.addListener(() {
       setState(() {}); // re-construct appBar on click
     });
@@ -62,7 +62,25 @@ class _MainPageState extends State<MainPage>  with SingleTickerProviderStateMixi
             },
           ),
         ];
-      case 1: // public lists
+      case 1: // shared lists
+        return <Widget>[
+          IconButton(
+            icon: const Icon(Icons.info),
+            onPressed: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text(
+                    '點擊清單可查看餐廳列表',
+                    textAlign: TextAlign.center,
+                  ),
+                  duration: Duration(seconds: 3),
+                  showCloseIcon: true,
+                ),
+              );
+            },
+          ),
+        ];
+      case 2: // public lists
         return <Widget>[
           IconButton(
             icon: const Icon(Icons.info),
@@ -100,7 +118,7 @@ class _MainPageState extends State<MainPage>  with SingleTickerProviderStateMixi
             color: theme.colorScheme.secondary,
             child: TabBar(
               controller: _tabCtrl,
-              tabs: const [Tab(text: '我的清單'), Tab(text: '公開清單')],
+              tabs: const [Tab(text: '我的清單'), Tab(text: '共享清單'), Tab(text: '公開清單')],
               labelColor: theme.colorScheme.primary,
               unselectedLabelColor: theme.colorScheme.onSurface,
               indicatorColor: theme.colorScheme.onPrimary,
@@ -152,6 +170,30 @@ class _MainPageState extends State<MainPage>  with SingleTickerProviderStateMixi
                       },
                       fromPersonal: true,
                     ),
+                  );
+                },
+              );
+            }
+          ),
+          /// shared lists
+          Consumer<AppState>(
+            builder: (context, appState, child) {
+              final sharedLists = appState.sharedLists;
+              if (sharedLists.isEmpty) {
+                return Center(
+                  child: Text('尚未有其他人與你共享清單', style: theme.textTheme.titleLarge,)
+                );
+              }
+              return ListView.builder(
+                padding: const EdgeInsets.all(14),
+                itemCount: sharedLists.length,
+                itemBuilder: (context, index) {
+                  final list = sharedLists[index];
+                  return ListDismissibleCard(
+                    list: list,
+                    dismissible: false,
+                    onDismissed: null,
+                    fromPersonal: true,
                   );
                 },
               );

--- a/lib/pages/restaurants_page.dart
+++ b/lib/pages/restaurants_page.dart
@@ -149,6 +149,13 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
                   return PublicizePersonalListDialog(list: widget.list);
                 },
               );
+            } else if (value == 'share') {
+              showDialog(
+                context: context,
+                builder: (context) {
+                  return SetShareWithUsersDialog(list: widget.list);
+                }
+              );
             }
           },
           itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
@@ -164,6 +171,13 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
               child: ListTile(
                 leading: Icon(Icons.public),
                 title: Text('公開清單'),
+              ),
+            ),
+            const PopupMenuItem<String>(
+              value: 'share',
+              child: ListTile(
+                leading: Icon(Icons.share),
+                title: Text('編輯共享用戶'),
               ),
             ),
           ],

--- a/lib/pages/restaurants_page.dart
+++ b/lib/pages/restaurants_page.dart
@@ -96,6 +96,7 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
   }
 
   List<Widget> _getAppBarActions() {
+    final theme = Theme.of(context);
     if (widget.editable) {
       return <Widget>[
         IconButton(
@@ -113,35 +114,6 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
             );
           },
         ),
-        IconButton(   // 新增餐廳
-          icon: Icon(Icons.add_box),
-          tooltip: "新增餐廳",
-          onPressed: () {
-            showDialog(
-              context: context,
-              builder: (context) {
-                return AddRestaurantDialog(listID: widget.list.listID);
-              }
-            );
-          },
-        ),
-        IconButton( // 公開清單
-          icon: Icon(Icons.public),
-          tooltip: "公開清單",
-          onPressed: () {
-            showDialog(
-              context: context,
-              builder: (context) {
-                return PublicizePersonalListDialog(list: widget.list);
-              }
-            );
-          },
-        ),
-        IconButton( // 隨機選擇
-          icon: Icon(Icons.shuffle),
-          tooltip: "隨機選擇餐廳",
-          onPressed: randomChooseRestaurant,
-        ),
         IconButton( // 篩選器
           icon: Icon(Icons.filter_list_alt),
           tooltip: "設置篩選條件",
@@ -153,6 +125,48 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
               }
             );
           },
+        ),
+        IconButton( // 隨機選擇
+          icon: Icon(Icons.shuffle),
+          tooltip: "隨機選擇餐廳",
+          onPressed: randomChooseRestaurant,
+        ),
+        PopupMenuButton<String>(
+          color: theme.colorScheme.secondary,
+          position: PopupMenuPosition.under,
+          onSelected: (String value) {
+            if (value == 'add_restaurant') {
+              showDialog(
+                context: context,
+                builder: (context) {
+                  return AddRestaurantDialog(listID: widget.list.listID);
+                }
+              );
+            } else if (value == 'publicize') {
+              showDialog(
+                context: context,
+                builder: (context) {
+                  return PublicizePersonalListDialog(list: widget.list);
+                },
+              );
+            }
+          },
+          itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+            const PopupMenuItem<String>(
+              value: 'add_restaurant',
+              child: ListTile(
+                leading: Icon(Icons.add_box),
+                title: Text('新增餐廳'),
+              ),
+            ),
+            const PopupMenuItem<String>(
+              value: 'publicize',
+              child: ListTile(
+                leading: Icon(Icons.public),
+                title: Text('公開清單'),
+              ),
+            ),
+          ],
         ),
       ];
     } else {
@@ -172,11 +186,6 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
             );
           },
         ),
-        IconButton( // 隨機選擇
-          icon: Icon(Icons.shuffle),
-          tooltip: "隨機選擇餐廳",
-          onPressed: randomChooseRestaurant,
-        ),
         IconButton( // 篩選器
           icon: Icon(Icons.filter_list_alt),
           tooltip: "設置篩選條件",
@@ -188,6 +197,11 @@ class _RestaurantsListScreenState extends State<RestaurantsListScreen> {
               }
             );
           },
+        ),
+        IconButton( // 隨機選擇
+          icon: Icon(Icons.shuffle),
+          tooltip: "隨機選擇餐廳",
+          onPressed: randomChooseRestaurant,
         ),
       ];
     }

--- a/lib/states/app_state.dart
+++ b/lib/states/app_state.dart
@@ -91,15 +91,23 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
           .where(PersonalListFields.userID, isEqualTo: _user!.uid)
           .snapshots()
           .listen((snapshot) {
-        _personalLists = snapshot.docs.map((doc) => PersonalList(
-          listID: doc.id ,
-          title: doc.data()[PersonalListFields.title] as String? ?? '無標題',
-          userID: doc.data()[PersonalListFields.userID] as String? ?? '用戶ID未知',
-          userName: doc.data()[PersonalListFields.userName] as String? ?? '未知用戶',
-          isPublic: doc.data()[PersonalListFields.isPublic] as bool? ?? false,
-          creatTime: doc.data()[PersonalListFields.creatTime] as Timestamp?,
-          updateTime: doc.data()[PersonalListFields.updateTime] as Timestamp?,
-        )).toList();
+        _personalLists = snapshot.docs.map((doc) {
+          final shareWithData = doc.data()[PersonalListFields.shareWith];
+          List<String>? shareWithList;
+          if (shareWithData != null && shareWithData is List) {
+            shareWithList = shareWithData.cast<String>().toList();
+          }
+          return PersonalList(
+            listID: doc.id ,
+            title: doc.data()[PersonalListFields.title] as String? ?? '無標題',
+            userID: doc.data()[PersonalListFields.userID] as String? ?? '用戶ID未知',
+            userName: doc.data()[PersonalListFields.userName] as String? ?? '未知用戶',
+            isPublic: doc.data()[PersonalListFields.isPublic] as bool? ?? false,
+            creatTime: doc.data()[PersonalListFields.creatTime] as Timestamp?,
+            updateTime: doc.data()[PersonalListFields.updateTime] as Timestamp?,
+            shareWith: shareWithList,
+          );
+        }).toList();
         logger.i('personalLists: ${_personalLists.map((list) => list.toString()).toList()}');
         notifyListeners(); 
       }, onError: (error) {
@@ -122,15 +130,23 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
           .where(PersonalListFields.isPublic, isEqualTo: true)
           .snapshots()
           .listen((snapshot) {
-        _publicLists = snapshot.docs.map((doc) => PersonalList(
-          listID: doc.id ,
-          title: doc.data()[PersonalListFields.title] as String? ?? '無標題',
-          userID: doc.data()[PersonalListFields.userID] as String? ?? '用戶ID未知',
-          userName: doc.data()[PersonalListFields.userName] as String? ?? '未知用戶',
-          isPublic: doc.data()[PersonalListFields.isPublic] as bool? ?? false,
-          creatTime: doc.data()[PersonalListFields.creatTime] as Timestamp?,
-          updateTime: doc.data()[PersonalListFields.updateTime] as Timestamp?,
-        )).toList();
+        _publicLists = snapshot.docs.map((doc) {
+          final shareWithData = doc.data()[PersonalListFields.shareWith];
+          List<String>? shareWithList;
+          if (shareWithData != null && shareWithData is List) {
+            shareWithList = shareWithData.cast<String>().toList();
+          }
+          return PersonalList(
+            listID: doc.id ,
+            title: doc.data()[PersonalListFields.title] as String? ?? '無標題',
+            userID: doc.data()[PersonalListFields.userID] as String? ?? '用戶ID未知',
+            userName: doc.data()[PersonalListFields.userName] as String? ?? '未知用戶',
+            isPublic: doc.data()[PersonalListFields.isPublic] as bool? ?? false,
+            creatTime: doc.data()[PersonalListFields.creatTime] as Timestamp?,
+            updateTime: doc.data()[PersonalListFields.updateTime] as Timestamp?,
+            shareWith: shareWithList,
+          );
+        }).toList();
         logger.i('publicLists: ${_publicLists.map((list) => list.toString()).toList()}');
         notifyListeners();
       }, onError: (error) {

--- a/lib/states/app_state.dart
+++ b/lib/states/app_state.dart
@@ -17,6 +17,10 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
   List<PersonalList> _personalLists = [];
   List<PersonalList> get personalLists => _personalLists;
 
+  StreamSubscription<QuerySnapshot>? _sharedListsSubscription;
+  List<PersonalList> _sharedLists = [];
+  List<PersonalList> get sharedLists => _sharedLists;
+
   StreamSubscription<QuerySnapshot>? _publicListsSubscription;
   List<PersonalList> _publicLists = [];
   List<PersonalList> get publicLists => _publicLists;
@@ -65,6 +69,7 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
         _user = user;
         notifyListeners();
         _updatePersonalListsSubscription();
+        _updateSharedListsSubscription();
         _updatePublicListsSubscription();
       });
     } catch (e) {
@@ -117,6 +122,45 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
       _personalListsSubscription?.cancel();
       _personalLists = [];
       logger.i('Cancel personalLists subscription');
+      notifyListeners();
+    }
+  }
+
+  void _updateSharedListsSubscription() {
+    if (_user != null) {
+      logger.i('Starting shared lists subscription for user: ${_user!.uid}');
+      _sharedListsSubscription = FirebaseFirestore.instance
+          .collection(CollectionNames.personalLists)
+          .where(PersonalListFields.userID, isNotEqualTo: _user!.uid) // 在共享清單顯示的時候不顯示使用者本人的清單
+          .where(PersonalListFields.shareWith, arrayContains: _user!.uid)
+          .snapshots()
+          .listen((snapshot) {
+        _sharedLists = snapshot.docs.map((doc) {
+          final shareWithData = doc.data()[PersonalListFields.shareWith];
+          List<String>? shareWithList;
+          if (shareWithData != null && shareWithData is List) {
+            shareWithList = shareWithData.cast<String>().toList();
+          }
+          return PersonalList(
+            listID: doc.id ,
+            title: doc.data()[PersonalListFields.title] as String? ?? '無標題',
+            userID: doc.data()[PersonalListFields.userID] as String? ?? '用戶ID未知',
+            userName: doc.data()[PersonalListFields.userName] as String? ?? '未知用戶',
+            isPublic: doc.data()[PersonalListFields.isPublic] as bool? ?? false,
+            creatTime: doc.data()[PersonalListFields.creatTime] as Timestamp?,
+            updateTime: doc.data()[PersonalListFields.updateTime] as Timestamp?,
+            shareWith: shareWithList,
+          );
+        }).toList();
+        logger.i('sharedLists: ${_sharedLists.map((list) => list.toString()).toList()}');
+        notifyListeners();
+      }, onError: (error) {
+        logger.w('監聽共享清單錯誤: $error');
+      });
+    } else {
+      _sharedListsSubscription?.cancel();
+      _sharedLists = [];
+      logger.i('Cancel sharedLists subscription');
       notifyListeners();
     }
   }

--- a/lib/widgets/card.dart
+++ b/lib/widgets/card.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../firebase/firebase_service.dart';
 import '../states/app_state.dart';
 import '../firebase/model.dart';
 import '../pages/restaurants_page.dart';

--- a/lib/widgets/dialog.dart
+++ b/lib/widgets/dialog.dart
@@ -7,6 +7,7 @@ import '../widgets/widgets.dart';
 import '../widgets/menu.dart';
 import '../firebase/firebase_service.dart';
 import '../firebase/model.dart';
+import '../firebase/constants.dart';
 import '../utils/geolocation_utils.dart';
 import '../logging/logging.dart';
 
@@ -1369,6 +1370,205 @@ class _SelectListDialogState extends State<SelectListDialog> {
         ),
       ],
       actionsAlignment: MainAxisAlignment.center
+    );
+  }
+}
+
+class SetShareWithUsersDialog extends StatefulWidget {
+  const SetShareWithUsersDialog({
+    required this.list,
+    super.key,
+  });
+
+  final PersonalList list;
+
+  @override
+  State<SetShareWithUsersDialog> createState() => _SetShareWithUsersDialogState();
+}
+
+class _SetShareWithUsersDialogState extends State<SetShareWithUsersDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  List<Map<String, dynamic>> _sharedUsers = [];
+
+  String _errorMessage = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSharedUsers();
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  bool _isValidEmail(String email) {
+    final emailRegExp = RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$');
+    return emailRegExp.hasMatch(email);
+  }
+
+  Future<void> _loadSharedUsers() async {
+    final response = await FirebaseService.getSharedUser(
+      listID: widget.list.listID,
+    );
+
+    setState(() {
+      _sharedUsers = response.usersList!;
+    });
+  }
+
+  Future<void> _addSharedUserByEmail() async {
+    setState(() {
+      _errorMessage = '';
+    });
+
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    final response = await FirebaseService.addSharedUserByEmail(
+      listID: widget.list.listID,
+      email: _emailController.text.trim(),
+    );
+
+    setState(() {
+      if (response.success) {
+        _emailController.clear();
+        _loadSharedUsers();
+      } else {
+        _errorMessage = response.message;
+        _loadSharedUsers();
+      }
+    });
+  }
+
+  Future<void> _removeSharedUserByID(String userID) async {
+    setState(() {
+      _errorMessage = '';
+    });
+
+    final response = await FirebaseService.removeSharedUser(
+      listID: widget.list.listID,
+      userID: userID,
+    );
+
+    setState(() {
+      if (response.success) {
+        _loadSharedUsers();
+      } else {
+        _errorMessage = response.message;
+        _loadSharedUsers();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      backgroundColor: theme.colorScheme.surface,
+      title: Center(
+        child: Text('設定共享使用者', style: theme.textTheme.titleLarge)
+      ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text('請輸入欲共享的使用者的電子郵件', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 6),
+
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Expanded(
+                  child: Form(
+                    key: _formKey,
+                    child: TextFormField(
+                      controller: _emailController,
+                      keyboardType: TextInputType.text,
+                      decoration: InputDecoration(
+                        labelText: '電子郵件',
+                        labelStyle: Theme.of(context).textTheme.titleMedium,
+                        prefixIcon: const Icon(Icons.email),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return '請輸入電子郵件';
+                        }
+                        if (!_isValidEmail(value)) {
+                          return '請輸入有效的電子郵件地址';
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 5),
+                PrimaryElevatedButton(
+                  onPressed: _addSharedUserByEmail,
+                  label: const Text('新增'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 5),
+      
+            if (_errorMessage.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              Text(
+                _errorMessage,
+                style: const TextStyle(color: Colors.red),
+              ),
+            ],
+            const SizedBox(height: 20),
+      
+            Center(
+              child: Text('目前已共享的使用者：', style: theme.textTheme.titleMedium)
+            ),
+            const SizedBox(height: 10),
+
+            if (_sharedUsers.isEmpty)
+              const Text('尚未共享給任何使用者')
+            else ...[
+              Container(
+                color: theme.colorScheme.secondary,
+                width: MediaQuery.of(context).size.width,
+                height: MediaQuery.of(context).size.height * 0.3,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: _sharedUsers.length,
+                  itemBuilder: (context, index) {
+                    final user = _sharedUsers[index];
+                    return ListTile(
+                      leading: Icon(Icons.person),
+                      title: Text(user[UserFileds.userName]),
+                      subtitle: Text(user[UserFileds.email]),
+                      trailing: IconButton(
+                        icon: Icon(Icons.delete, color: theme.colorScheme.error),
+                        onPressed: () => {
+                          _removeSharedUserByID(
+                            user[PersonalListFields.userID],
+                          ),
+                        },
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        PrimaryElevatedButton(
+          onPressed: () => Navigator.of(context).pop(),
+          label: const Text('關閉'),
+        ),
+      ],
+      actionsAlignment: MainAxisAlignment.center,
     );
   }
 }


### PR DESCRIPTION
* 把新增餐廳跟公開清單移動到 PopupMenu 裡面，讓我的清單跟公開清單就差在多了 PopupMenu 的符號，有更直覺的差異。
* 移動設置篩選條件跟隨機選擇餐廳到外面，並且讓設置篩選條件位於隨機選擇餐廳前面，呈現先選擇條件，再執行隨機抽取的味道。
* 共享者可以對該清單做任何事，除了刪除該清單以外，例如共享者也可以再邀請其他人共享該清單、刪除其他共享者 (除了清單擁有者)、公開清單、新增餐廳等等。
* 若要在 Dialog 中使用 ListView 來呈現元件，則必須把 ListView 包在 Container 或 SizedBox 裡面，並指定寬度和高度，否則會出現尚未定義大小的錯誤。
* 若要在 TextFormField 的右邊新增按鈕，則需要用 Expanded 或 Flex 把 TextFormField 包起來，否則會出現尚未定義大小的錯誤。
* 如果需要變更共享者的清單權限，則需要重新決定傳給 RestaurantsListScreen 的參數，依參數決定可以使用那些功能。

<img src="https://github.com/user-attachments/assets/9c81145e-4f0f-4b4c-83b8-c205244f69da" width="300">
<img src="https://github.com/user-attachments/assets/0ce59744-7ceb-43ac-9a3c-0c203ec28f47" width="300">
<img src="https://github.com/user-attachments/assets/be5ccd81-5330-474e-bfbf-bdb81dc6a4a2" width="300">