### PR TITLE
favorite_events_page

### DIFF
--- a/lib/firebase/firebase_service.dart
+++ b/lib/firebase/firebase_service.dart
@@ -1037,6 +1037,30 @@ class FirebaseService {
     return userName;
   }
 
+  static final _favoritesRef = FirebaseFirestore.instance.collection('favorites_events');
+
+  static Future<void> addFavoriteEvent({required String userId, required String eventId}) async {
+    final docId = '${userId}_$eventId';
+    await _favoritesRef.doc(docId).set({
+      'userId': userId,
+      'eventId': eventId,
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+  }
+
+  static Future<void> removeFavoriteEvent({required String userId, required String eventId}) async {
+    final docId = '${userId}_$eventId';
+    await _favoritesRef.doc(docId).delete();
+  }
+
+  static Stream<List<String>> favoriteEventIdsStream(String userId) {
+    return _favoritesRef
+        .where('userId', isEqualTo: userId)
+        .snapshots()
+        .map((snap) => snap.docs.map((doc) => doc['eventId'] as String).toList());
+  }
+
+
 }
 
   

--- a/lib/firebase/firebase_service.dart
+++ b/lib/firebase/firebase_service.dart
@@ -1009,7 +1009,6 @@ class FirebaseService {
     return response;
   }
 
-  /// 用 email 的 user.displayName 會是 null
   static Future<String?> getUserName() async {
     final user = FirebaseAuth.instance.currentUser;
     String? userName;
@@ -1059,8 +1058,6 @@ class FirebaseService {
         .snapshots()
         .map((snap) => snap.docs.map((doc) => doc['eventId'] as String).toList());
   }
-
-
 }
 
   

--- a/lib/pages/event_page.dart
+++ b/lib/pages/event_page.dart
@@ -60,6 +60,7 @@ class _EventPageState extends State<EventPage> with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
       _currentPosition();
     }
@@ -121,7 +122,7 @@ class _EventPageState extends State<EventPage> with WidgetsBindingObserver {
               },
             ),
             const SizedBox(width: 32),
-            const Text('以食會友'), // 這是你的標題
+            const Text('以食會友'), 
           ],
         ),
         actions: [

--- a/lib/pages/favorite_events_page.dart
+++ b/lib/pages/favorite_events_page.dart
@@ -1,0 +1,148 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:what_for_meal/firebase/firebase_service.dart';
+import 'package:what_for_meal/firebase/model.dart';
+import 'package:what_for_meal/widgets/card.dart';
+import '../firebase/constants.dart';
+
+class FavoriteEventsPage extends StatefulWidget {
+  final String userId;
+  const FavoriteEventsPage({super.key, required this.userId});
+
+  @override
+  State<FavoriteEventsPage> createState() => _FavoriteEventsPageState();
+}
+
+class _FavoriteEventsPageState extends State<FavoriteEventsPage> {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('收藏的活動'),
+        backgroundColor: theme.colorScheme.primary,
+        foregroundColor: theme.colorScheme.onPrimary,
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(15.0),
+        child: StreamBuilder<List<String>>(
+          stream: FirebaseService.favoriteEventIdsStream(widget.userId),
+          builder: (context, favSnapshot) {
+            final favIds = favSnapshot.data ?? [];
+            if (favIds.isEmpty) {
+              return const Center(child: Text('尚未收藏任何活動'));
+            }
+            return StreamBuilder<List<Event>>(
+              stream: FirebaseFirestore.instance
+                  .collection(CollectionNames.events)
+                  .where(FieldPath.documentId, whereIn: favIds)
+                  .snapshots()
+                  .map((snap) => snap.docs.map((doc) {
+                        final data = doc.data();
+                        return Event(
+                          id: doc.id,
+                          title: data[EventFields.title] ?? '',
+                          goal: data[EventFields.goal] ?? '',
+                          description: data[EventFields.description] ?? '',
+                          dateTime: data[EventFields.dateTime] as Timestamp,
+                          numberOfPeople: (data[EventFields.numberOfPeople] as num?)?.toInt() ?? 1,
+                          restoName: data[EventFields.restoName] ?? '',
+                          address: data[EventFields.address] ?? '',
+                          participants: List<String>.from(data[EventFields.participants] ?? []),
+                          participantNames: List<String>.from(data[EventFields.participantNames] ?? []),
+                        );
+                      }).toList()),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                final events = snapshot.data!;
+                if (events.isEmpty) {
+                  return const Center(child: Text('收藏的活動可能已被刪除'));
+                }
+
+                return ListView.builder(
+                  itemCount: events.length,
+                  itemBuilder: (context, index) {
+                    final event = events[index];
+                    final alreadyJoined = event.participants.contains(widget.userId);
+
+                    return EventCard(
+                      isCreator: false,
+                      event: event,
+                      onPlusOne: alreadyJoined
+                          ? null
+                          : () async {
+                              final messenger = ScaffoldMessenger.of(context);
+                              final result = await FirebaseService.joinEvent(eventId: event.id);
+                              if (!mounted) return;
+                              if (result.success) {
+                                setState(() {});
+                              }
+                              messenger.showSnackBar(
+                                SnackBar(
+                                  content: Text(result.message),
+                                  duration: const Duration(seconds: 2),
+                                ),
+                              );
+                            },
+                      onCancel: alreadyJoined
+                          ? () async {
+                              final messenger = ScaffoldMessenger.of(context);
+                              final result = await FirebaseService.cancelEvent(eventId: event.id);
+                              if (!mounted) return;
+                              if (result.success) {
+                                setState(() {});
+                              }
+                              messenger.showSnackBar(
+                                SnackBar(
+                                  content: Text(result.message),
+                                  duration: const Duration(seconds: 2),
+                                ),
+                              );
+                            }
+                          : null,
+                      onEdit: null,
+                      onDelete: null,
+                      favoriteEventIds: favIds,
+                      onToggleFavorite: (isFav) async {
+                        final messenger = ScaffoldMessenger.of(context);
+                        if (isFav) {
+                          await FirebaseService.removeFavoriteEvent(
+                            userId: widget.userId,
+                            eventId: event.id,
+                          );
+                          if (!mounted) return;
+                          messenger.showSnackBar(
+                            const SnackBar(
+                              content: Text('已取消收藏'),
+                              duration: Duration(seconds: 2),
+                            ),
+                          );
+                        } else {
+                          await FirebaseService.addFavoriteEvent(
+                            userId: widget.userId,
+                            eventId: event.id,
+                          );
+                          if (!mounted) return;
+                          messenger.showSnackBar(
+                            const SnackBar(
+                              content: Text('已加入收藏'),
+                              duration: Duration(seconds: 2),
+                            ),
+                          );
+                        }
+                      },
+                    );
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/my_events_page.dart
+++ b/lib/pages/my_events_page.dart
@@ -5,7 +5,6 @@ import 'package:what_for_meal/firebase/model.dart';
 import 'package:what_for_meal/pages/event_form_page.dart';
 import 'package:what_for_meal/widgets/card.dart';
 import 'package:what_for_meal/widgets/dialog.dart';
-
 import '../firebase/constants.dart';
 
 class MyEventsPage extends StatefulWidget {
@@ -18,13 +17,9 @@ class MyEventsPage extends StatefulWidget {
 
 class _MyEventsPageState extends State<MyEventsPage> {
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('已參加的活動'),
@@ -48,7 +43,8 @@ class _MyEventsPageState extends State<MyEventsPage> {
                     '1. 點擊活動可查看詳細資訊\n'
                     '2. 參與者點擊 -1 可取消參加活動\n'
                     '3. 創建者可點擊垃圾桶刪除活動\n'
-                    '4. 創建者可長按編輯活動\n',
+                    '4. 創建者可長按編輯活動\n'
+                    '5. 點擊愛心可收藏活動',
                     textAlign: TextAlign.left,
                   ),
                   duration: Duration(seconds: 6),
@@ -61,106 +57,152 @@ class _MyEventsPageState extends State<MyEventsPage> {
       ),
       body: Padding(
         padding: const EdgeInsets.all(12),
-        child: StreamBuilder<List<Event>>(
-          stream: FirebaseFirestore.instance
-              .collection(CollectionNames.events)
-              .where(EventFields.participants, arrayContains: widget.userId)
-              .where(EventFields.dateTime, isGreaterThanOrEqualTo: Timestamp.now())
-              .orderBy(EventFields.dateTime)
-              .snapshots()
-              .map((snap) => snap.docs.map((doc) {
-                    return Event(
-                      id: doc.id,
-                      title: doc[EventFields.title] as String? ?? '',
-                      goal: doc[EventFields.goal] as String? ?? '',
-                      description: doc[EventFields.description] as String? ?? '',
-                      dateTime: doc[EventFields.dateTime] as Timestamp,
-                      numberOfPeople: (doc[EventFields.numberOfPeople] as num?)?.toInt() ?? 1,
-                      restoName: doc[EventFields.restoName] as String? ?? '',
-                      address: doc[EventFields.address] as String? ?? '',
-                      participants: List<String>.from(doc[EventFields.participants] ?? <String>[]),
-                      participantNames: List<String>.from(doc[EventFields.participantNames] ?? <String>[]),
-                    );
-                  }).toList()),
-          builder: (context, snapshot) {
-            if (snapshot.connectionState != ConnectionState.active) {
-              return const Center(child: CircularProgressIndicator());
-            }
-            if (snapshot.hasError) {
-              return Center(child: Text('載入失敗：${snapshot.error}'));
-            }
-            final events = snapshot.data ?? <Event>[];
-            if (events.isEmpty) {
-              return const Center(child: Text('尚未參加任何活動'));
-            }
+        child: StreamBuilder<List<String>>(
+          stream: FirebaseService.favoriteEventIdsStream(widget.userId),
+          builder: (context, favSnapshot) {
+            final favoriteIds = favSnapshot.data ?? [];
 
-            return ListView.builder(
-              padding: const EdgeInsets.all(8),
-              itemCount: events.length,
-              itemBuilder: (context, index) {
-                final event = events[index];
-                final isCreator = event.participants.first == widget.userId;
+            return StreamBuilder<List<Event>>(
+              stream: FirebaseFirestore.instance
+                  .collection(CollectionNames.events)
+                  .where(EventFields.participants, arrayContains: widget.userId)
+                  .where(EventFields.dateTime, isGreaterThanOrEqualTo: Timestamp.now())
+                  .orderBy(EventFields.dateTime)
+                  .snapshots()
+                  .map((snap) => snap.docs.map((doc) {
+                        return Event(
+                          id: doc.id,
+                          title: doc[EventFields.title] ?? '',
+                          goal: doc[EventFields.goal] ?? '',
+                          description: doc[EventFields.description] ?? '',
+                          dateTime: doc[EventFields.dateTime] as Timestamp,
+                          numberOfPeople: (doc[EventFields.numberOfPeople] as num?)?.toInt() ?? 1,
+                          restoName: doc[EventFields.restoName] ?? '',
+                          address: doc[EventFields.address] ?? '',
+                          participants: List<String>.from(doc[EventFields.participants] ?? []),
+                          participantNames: List<String>.from(doc[EventFields.participantNames] ?? []),
+                        );
+                      }).toList()),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState != ConnectionState.active) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (snapshot.hasError) {
+                  return Center(child: Text('載入失敗：${snapshot.error}'));
+                }
 
-                return EventCard(
-                  isCreator: isCreator,
-                  event: event,
-                  onPlusOne: null,
-                  onCancel: () async {
-                    final confirm = await showDialog<bool>(
-                      context: context,
-                      builder: (_) => DoubleCheckDismissDialog(
-                        titleText: '確認取消',
-                        displayText: '確定要取消參加活動「${event.title}」嗎？',
-                      ),
-                    );
-                    if (confirm == true) {
-                      final res = await FirebaseService.cancelEvent(eventId: event.id);
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: res.success
-                                ? Text('已取消參加活動 ${event.title}', textAlign: TextAlign.center)
-                                : Text(res.message, textAlign: TextAlign.center),
-                            duration: const Duration(seconds: 3),
-                            showCloseIcon: true,
+                final events = snapshot.data ?? [];
+                if (events.isEmpty) {
+                  return const Center(child: Text('尚未參加任何活動'));
+                }
+
+                return ListView.builder(
+                  padding: const EdgeInsets.all(8),
+                  itemCount: events.length,
+                  itemBuilder: (context, index) {
+                    final event = events[index];
+                    final isCreator = event.participants.first == widget.userId;
+
+                    return EventCard(
+                      isCreator: isCreator,
+                      event: event,
+                      onPlusOne: null,
+                      onCancel: () async {
+                        final confirm = await showDialog<bool>(
+                          context: context,
+                          builder: (_) => DoubleCheckDismissDialog(
+                            titleText: '確認取消',
+                            displayText: '確定要取消參加活動「${event.title}」嗎？',
                           ),
                         );
-                      }
-                    }
-                  },
-                  onEdit: isCreator
-                      ? () async {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(builder: (_) => EventFormPage(event: event)),
-                          );
-                        }
-                      : null,
-                  onDelete: isCreator
-                      ? () async {
-                          final confirm = await showDialog<bool>(
-                            context: context,
-                            builder: (_) => DoubleCheckDismissDialog(
-                              titleText: '確認刪除',
-                              displayText: '確定要刪除活動「${event.title}」嗎？此操作無法復原。',
-                            ),
-                          );
-                          if (confirm == true) {
-                            final res = await FirebaseService.deleteEvent(eventId: event.id);
-                            if (context.mounted) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content: res.success
-                                      ? Text('已刪除活動 ${event.title}', textAlign: TextAlign.center)
-                                      : Text(res.message, textAlign: TextAlign.center),
-                                  duration: const Duration(seconds: 3),
-                                  showCloseIcon: true,
-                                ),
-                              );
-                            }
+                        if (confirm == true) {
+                          final res = await FirebaseService.cancelEvent(eventId: event.id);
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: res.success
+                                    ? Text('已取消參加活動 ${event.title}', textAlign: TextAlign.center)
+                                    : Text(res.message, textAlign: TextAlign.center),
+                                duration: const Duration(seconds: 3),
+                                showCloseIcon: true,
+                              ),
+                            );
                           }
                         }
-                      : null,
+                      },
+                      onEdit: isCreator
+                          ? () async {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(builder: (_) => EventFormPage(event: event)),
+                              );
+                            }
+                          : null,
+                      onDelete: isCreator
+                          ? () async {
+                              final confirm = await showDialog<bool>(
+                                context: context,
+                                builder: (_) => DoubleCheckDismissDialog(
+                                  titleText: '確認刪除',
+                                  displayText: '確定要刪除活動「${event.title}」嗎？此操作無法復原。',
+                                ),
+                              );
+                              if (confirm == true) {
+                                final res = await FirebaseService.deleteEvent(eventId: event.id);
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: res.success
+                                          ? Text('已刪除活動 ${event.title}', textAlign: TextAlign.center)
+                                          : Text(res.message, textAlign: TextAlign.center),
+                                      duration: const Duration(seconds: 3),
+                                      showCloseIcon: true,
+                                    ),
+                                  );
+                                }
+                              }
+                            }
+                          : null,
+                      favoriteEventIds: favoriteIds,
+                      onToggleFavorite: (isFav) async {
+                        final messenger = ScaffoldMessenger.of(context);
+
+                        if (isFav) {
+                          await FirebaseService.removeFavoriteEvent(
+                            userId: widget.userId,
+                            eventId: event.id,
+                          );
+                          if (context.mounted) {
+                            messenger.removeCurrentSnackBar();
+                            Future.delayed(const Duration(milliseconds: 100), () {
+                              messenger.showSnackBar(
+                                const SnackBar(
+                                  content: Text('已取消收藏'),
+                                  duration: Duration(seconds: 2),
+                                ),
+                              );
+                            });
+                          }
+                        } else {
+                          await FirebaseService.addFavoriteEvent(
+                            userId: widget.userId,
+                            eventId: event.id,
+                          );
+                          if (context.mounted) {
+                            messenger.removeCurrentSnackBar();
+                            Future.delayed(const Duration(milliseconds: 100), () {
+                              messenger.showSnackBar(
+                                const SnackBar(
+                                  content: Text('已加入收藏'),
+                                  duration: Duration(seconds: 2),
+                                ),
+                              );
+                            });
+                          }
+                        }
+                      },
+                    );
+                  },
                 );
               },
             );

--- a/lib/widgets/card.dart
+++ b/lib/widgets/card.dart
@@ -228,15 +228,18 @@ class RestaurantDismissibleCard extends StatelessWidget {
     }
   }
 }
+
 class EventCard extends StatelessWidget {
   const EventCard({
+    super.key,
     required this.isCreator,
     required this.event,
     required this.onEdit,
     required this.onCancel,
     required this.onPlusOne,
     required this.onDelete,
-    super.key,
+    required this.favoriteEventIds,
+    required this.onToggleFavorite,
   });
 
   final Event event;
@@ -245,65 +248,162 @@ class EventCard extends StatelessWidget {
   final Function? onCancel;
   final Function? onPlusOne;
   final Function? onDelete;
+  final List<String> favoriteEventIds;
+  final Function(bool isCurrentlyFav)? onToggleFavorite;
+
+  bool get isFavorited => favoriteEventIds.contains(event.id);
+
+  String _getCountdownText(DateTime eventTime) {
+    final now = DateTime.now();
+    final diff = eventTime.difference(now);
+
+    if (diff.isNegative) return '已開始';
+    if (diff.inDays > 0) return '剩 ${diff.inDays} 天';
+    if (diff.inHours > 0) return '剩 ${diff.inHours} 小時';
+    if (diff.inMinutes > 0) return '剩 ${diff.inMinutes} 分';
+    return '即將開始';
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final countdown = _getCountdownText(event.dateTime.toDate());
+    final creatorName = event.participantNames.isNotEmpty
+        ? event.participantNames.first
+        : '未知';
 
-    return Card(
-        margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        clipBehavior: Clip.hardEdge,
-        child: ListTile(
-          leading: const Icon(Icons.event_available_rounded),
-          title: Text(event.title),
-          titleTextStyle: theme.textTheme.titleLarge,
-          subtitle: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('時間: ${event.formattedDate} ${event.formattedTime}'),
-              Text('地址: ${event.address}'),
-              const SizedBox(height: 6),
-            ],
+    ButtonStyle filledStyle(Color bgColor) => FilledButton.styleFrom(
+      backgroundColor: bgColor,
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 10),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+    );
+
+    List<Widget> actionButtons = [
+      Expanded(
+        child: FilledButton.icon(
+          icon: SizedBox(
+            width: 20,
+            child: Icon(
+              isFavorited ? Icons.favorite : Icons.favorite_border,
+              color: isFavorited ? Colors.red : theme.colorScheme.onPrimary,
+            ),
           ),
-          subtitleTextStyle: theme.textTheme.titleSmall,
-          trailing: Wrap(
-            spacing: 4,
-            children: [
-              if (onPlusOne != null)
-                IconButton(
-                  icon: const Icon(Icons.exposure_plus_1),
-                  tooltip: '參加活動',
-                  onPressed: () => onPlusOne!(),
-                ),
-              if (!isCreator && onCancel != null)
-                IconButton(
-                  icon: const Icon(Icons.exposure_minus_1),
-                  tooltip: '取消參加',
-                  onPressed: () => onCancel!(),
-                ),
-              if (isCreator && onDelete != null)
-                IconButton(
-                  color: theme.colorScheme.error,
-                  icon: const Icon(Icons.delete),
-                  tooltip: '刪除活動',
-                  onPressed: () => onDelete!(),
-                ),
-            ],
+          label: Text(
+            isFavorited ? '取消收藏' : '收藏',
+            style: TextStyle(color: theme.colorScheme.onPrimary),
           ),
-          onTap: () {
-            showDialog<Event>(
-              context: context,
-              builder: (_) => EventDetailDialog(event: event),
-            );
-          },
-          onLongPress: () {
-            if (isCreator && onEdit != null) {
-              onEdit!();
-            }
-          },
+          style: filledStyle(theme.colorScheme.primary),
+          onPressed: () => onToggleFavorite?.call(isFavorited),
+        ),
+      ),
+    ];
+
+    if (onPlusOne != null) {
+      actionButtons.add(const SizedBox(width: 8));
+      actionButtons.add(
+        Expanded(
+          child: FilledButton.icon(
+            icon: const SizedBox(
+              width: 20,
+              child: Icon(Icons.exposure_plus_1, color: Colors.white),
+            ),
+            label: Text('參加', style: TextStyle(color: theme.colorScheme.onPrimary)),
+            style: filledStyle(theme.colorScheme.primary),
+            onPressed: () => onPlusOne!(),
+          ),
         ),
       );
+    }
+
+    if (!isCreator && onCancel != null) {
+      actionButtons.add(const SizedBox(width: 8));
+      actionButtons.add(
+        Expanded(
+          child: FilledButton.icon(
+            icon: const SizedBox(
+              width: 20,
+              child: Icon(Icons.exposure_minus_1, color: Colors.white),
+            ),
+            label: Text('取消參加', style: TextStyle(color: theme.colorScheme.onPrimary)),
+            style: filledStyle(theme.colorScheme.primary),
+            onPressed: () => onCancel!(),
+          ),
+        ),
+      );
+    }
+
+    if (isCreator && onDelete != null) {
+      actionButtons.add(const SizedBox(width: 8));
+      actionButtons.add(
+        Expanded(
+          child: FilledButton.icon(
+            icon: SizedBox(
+              width: 20,
+              child: Icon(Icons.delete, color: theme.colorScheme.onPrimary),
+            ),
+            label: Text('刪除', style: TextStyle(color: theme.colorScheme.onPrimary)),
+            style: filledStyle(theme.colorScheme.error),
+            onPressed: () => onDelete!(),
+          ),
+        ),
+      );
+    }
+
+    return InkWell(
+      onTap: () {
+        showDialog(
+          context: context,
+          builder: (_) => EventDetailDialog(event: event),
+        );
+      },
+      onLongPress: () {
+        if (isCreator && onEdit != null) {
+          onEdit!();
+        }
+      },
+      child: Card(
+        margin: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        clipBehavior: Clip.hardEdge,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 標題與倒數
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      event.title,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleLarge,
+                    ),
+                  ),
+                  Text(
+                    countdown,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+
+              // 活動詳細資料
+              Text('時間: ${event.formattedDate} ${event.formattedTime}'),
+              Text('地址: ${event.address}'),
+              Text('人數：${event.participantNames.length} / ${event.numberOfPeople}'),
+              Text('創建者：$creatorName'),
+              const SizedBox(height: 12),
+
+              // 一行不換的按鈕列
+              Row(children: actionButtons),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
-
-

--- a/lib/widgets/card.dart
+++ b/lib/widgets/card.dart
@@ -369,7 +369,6 @@ class EventCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // 標題與倒數
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
@@ -391,14 +390,11 @@ class EventCard extends StatelessWidget {
               ),
               const SizedBox(height: 6),
 
-              // 活動詳細資料
               Text('時間: ${event.formattedDate} ${event.formattedTime}'),
               Text('地址: ${event.address}'),
               Text('人數：${event.participantNames.length} / ${event.numberOfPeople}'),
               Text('創建者：$creatorName'),
               const SizedBox(height: 12),
-
-              // 一行不換的按鈕列
               Row(children: actionButtons),
             ],
           ),


### PR DESCRIPTION
新增收藏活動功能:

1.點擊活動下方收藏按鈕可將活動加入到已收藏的活動
2.左上角愛心按鈕點擊後可察看我的收藏活動

<img src="https://github.com/user-attachments/assets/40cd4ab5-143c-424d-b648-c0bba29906cb" width="200">

<img src="https://github.com/user-attachments/assets/058e8f5a-bf84-45bc-9573-c59c89697ac5" width="200">


新增活動詳情google map連結:

<img src="https://github.com/user-attachments/assets/9564856e-0c4f-4ba9-8adc-8b85fa946bed" width="200">


優化界面:

1.更改+1參加活動按鈕、刪除活動按鈕位置
2.更改活動詳情顯示內容

<img src="https://github.com/user-attachments/assets/22ddde0a-8648-4480-9921-6a879e2432a7" width="200">
